### PR TITLE
Documentation on Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ class Api::Post
   # The 'index' action in Rails.
   # Also maps to the 'list_posts' command as an RPC call
   operation :index do
+    desc 'Lists the posts for a user'
     # Define this if you need to map parameters in the URL
     url '/:username/posts'
 

--- a/examples/newsfeed/app/models/api/post.rb
+++ b/examples/newsfeed/app/models/api/post.rb
@@ -31,8 +31,8 @@ class Api::Post
     integer :post_id, uri: true, required: true, as: :id
   end
 
-  desc "Creates a new post"
   operation :create do
+    desc "Creates a new post"
     url '/:username/posts'
 
     input do

--- a/examples/newsfeed/app/models/api/user.rb
+++ b/examples/newsfeed/app/models/api/user.rb
@@ -13,8 +13,8 @@ class Api::User
     timestamp :created_at
   end
 
-  desc 'Creates a new user'
   operation :create do
+    desc 'Creates a new user'
     url '/:username'
 
     input do
@@ -40,8 +40,8 @@ class Api::User
     end
   end
 
-  desc 'List all users'
   operation :index do
+    desc 'List all users'
     output(:list) { username as: [:user, :username] }
   end
 

--- a/examples/newsfeed/app/models/api/user.rb
+++ b/examples/newsfeed/app/models/api/user.rb
@@ -13,6 +13,7 @@ class Api::User
     timestamp :created_at
   end
 
+  desc 'Creates a new user'
   operation :create do
     url '/:username'
 
@@ -24,6 +25,7 @@ class Api::User
   end
 
   operation :follow do
+    desc 'Follows another user'
     url '/:username/follow/:following_username'
     verb :post
 
@@ -38,11 +40,13 @@ class Api::User
     end
   end
 
+  desc 'List all users'
   operation :index do
     output(:list) { username as: [:user, :username] }
   end
 
   operation :show do
+    desc 'Display a user'
     url '/:username'
     input { string :username, uri: true, required: true }
     output :user

--- a/lib/seahorse/model.rb
+++ b/lib/seahorse/model.rb
@@ -28,18 +28,12 @@ module Seahorse
         Seahorse::Router.new(self).add_routes(router)
       end
 
-      def desc(text)
-        @desc = text
-      end
-
       def operation(name, &block)
         name, action = *operation_name_and_action(name)
         @actions ||= {}
         @operations ||= {}
         @operations[name] = Operation.new(self, name, action, &block)
-        @operations[name].documentation = @desc unless @operations[name].documentation
         @actions[action] = @operations[name]
-        @desc = nil
       end
 
       def operation_from_action(action)

--- a/lib/seahorse/model.rb
+++ b/lib/seahorse/model.rb
@@ -37,7 +37,7 @@ module Seahorse
         @actions ||= {}
         @operations ||= {}
         @operations[name] = Operation.new(self, name, action, &block)
-        @operations[name].documentation = @desc
+        @operations[name].documentation = @desc unless @operations[name].documentation
         @actions[action] = @operations[name]
         @desc = nil
       end

--- a/lib/seahorse/operation.rb
+++ b/lib/seahorse/operation.rb
@@ -40,6 +40,10 @@ module Seahorse
       url ? (@url = url) : @url
     end
 
+    def desc(desc = nil)
+      desc ? (@documentation = desc) : @documentation
+    end
+
     def input(type = nil, &block)
       @input ||= ShapeBuilder.type_class_for(type || 'structure').new
       type || block ? ShapeBuilder.new(@input).build(&block) : @input


### PR DESCRIPTION
The block that creates an Operation can set the documentation for
the operation via a new desc method, e.g.:

``` ruby
operation :create do
  desc 'Creates a user'
  url '/:username'
  ..
end
```

The existing desc class method added by Seahorse::Model continues to
work, but the new method on Operation takes precedence.

The example app is updated to show both approaches, including using
both in the same model.

I think the class method should be removed from the Model module
but did not want to make this a breaking change.
