### PR TITLE
Add option not to draw RPC routes

### DIFF
--- a/lib/seahorse/model.rb
+++ b/lib/seahorse/model.rb
@@ -5,9 +5,12 @@ module Seahorse
     class << self
       def apis; @@apis end
 
-      def add_all_routes(router)
+      # @param router
+      # @param options [Hash] opts options for drawing routes
+      # @option options [Boolean] :exclude_rpc_routes Do not add routes for RPC calls
+      def add_all_routes(router, options = {})
         Dir.glob("#{Rails.root}/app/models/api/*.rb").each {|f| load f }
-        @@apis.values.each {|api| api.add_routes(router) }
+        @@apis.values.each {|api| api.add_routes(router, options) }
       end
     end
 
@@ -24,8 +27,8 @@ module Seahorse
         name.underscore.gsub(/_api$|^api\//, '')
       end
 
-      def add_routes(router)
-        Seahorse::Router.new(self).add_routes(router)
+      def add_routes(router, options = {})
+        Seahorse::Router.new(self, options).add_routes(router)
       end
 
       def desc(text)

--- a/lib/seahorse/router.rb
+++ b/lib/seahorse/router.rb
@@ -1,16 +1,19 @@
 module Seahorse
   class Router
-    def initialize(model)
+    def initialize(model, options = {})
       @model = model
+      @exclude_rpc_routes = options[:exclude_rpc_routes]
     end
 
     def add_routes(router)
       operations = @model.operations
       controller = @model.model_name.pluralize
       operations.each do |name, operation|
-        router.match "/#{name}" => "#{controller}##{operation.action}",
-          defaults: { format: 'json' },
-          via: [:get, operation.verb.to_sym].uniq
+        unless @exclude_rpc_routes
+          router.match "/#{name}" => "#{controller}##{operation.action}",
+            defaults: { format: 'json' },
+            via: [:get, operation.verb.to_sym].uniq
+        end
         router.match operation.url => "#{controller}##{operation.action}",
           defaults: { format: 'json' },
           via: operation.verb


### PR DESCRIPTION
Eventually finer-grained options could be added at the Model and Operation level to prevent drawing routes corresponding to RPC calls.
